### PR TITLE
W10S: Split between the *.ini and TODO

### DIFF
--- a/Release/TODO.txt
+++ b/Release/TODO.txt
@@ -1,0 +1,24 @@
+The list of things to do.
+
+# Also check
+#  - Background apps
+# delete :desktop Microsoft Edge.lnk
+# delete: "C:\Users\Martine\AppData\Roaming\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\Microsoft Edge.lnk"
+# check: C:\Users\Martine\AppData\Roaming\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar
+#
+# check:
+# %AppData%\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar
+# %AppData%\Microsoft\Internet Explorer\Quick Launch\User Pinned\StartMenu
+
+# Check - Computer\HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Run
+# Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run
+# Computer\HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Run
+# Computer\HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Run
+
+# TODO: Always inhibit C:\WINDOWS\System32\Speech\SpeechUX\SpeechUXWiz.exe in
+# every way possible, due to persistent popup coming up through an unknown shortcut
+# (if any, maybe it just randomly comes up and wants to be set up, even with the
+# thing disabled)
+
+# Windows Feedback Hub
+# C:\Program Files\WindowsApps\Microsoft.WindowsFeedbackHub_1.2203.761.0_x64__8wekyb3d8bbwe

--- a/Release/WinSetter.ini
+++ b/Release/WinSetter.ini
@@ -1,18 +1,3 @@
-# Also check
-#  - Background apps
-# delete :desktop Microsoft Edge.lnk
-# delete: "C:\Users\Martine\AppData\Roaming\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\Microsoft Edge.lnk"
-# check: C:\Users\Martine\AppData\Roaming\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar
-#
-# check:
-# %AppData%\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar
-# %AppData%\Microsoft\Internet Explorer\Quick Launch\User Pinned\StartMenu
-
-# Check - Computer\HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Run
-# Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run
-# Computer\HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Run
-# Computer\HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Run
-
 # Task Scheduler Items
 TASK SCHEDULER: STARTS_WITH "\Google" DISABLE
 TASK SCHEDULER: STARTS_WITH "\MicrosoftEdge" DISABLE
@@ -149,21 +134,17 @@ SET SERVICE STATE "MapsBroker" "SERVICE_DEMAND_START" # Downloaded Maps Manager
 SET SERVICE STATE "NativePushService" "SERVICE_DISABLED" #Wondershare Native Push Service
 
 ###################################################################################################
-# FUTURE THINGS
+# DELETE FILES
 ###################################################################################################
-
-# Sound Card
-SETSOUNDCARD "Speakers (Sound Blaster AE-9)"
-
-# TODO: Always inhibit C:\WINDOWS\System32\Speech\SpeechUX\SpeechUXWiz.exe in
-# every way possible, due to persistent popup coming up through an unknown shortcut
-# (if any, maybe it just randomly comes up and wants to be set up, even with the
-# thing disabled)
-
-# Windows Feedback Hub
-# C:\Program Files\WindowsApps\Microsoft.WindowsFeedbackHub_1.2203.761.0_x64__8wekyb3d8bbwe
 
 DELETE "%userprofile%\Desktop\Microsoft Edge.lnk"
 DELETE "%userprofile%\AppData\Roaming\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\Microsoft Edge.lnk"
 DELETE "%userprofile%\AppData\Roaming\Microsoft\Internet Explorer\Quick Launch\Microsoft Edge.lnk"
 DELETE "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Microsoft Edge.lnk"
+
+###################################################################################################
+# FUTURE THINGS
+###################################################################################################
+
+# Sound Card
+SETSOUNDCARD "Speakers (Sound Blaster AE-9)"


### PR DESCRIPTION
This has been going on for a while: the list of things to do and notes were part of the production *.ini file. That is far from nice, thus finally splitting the non-settings into a TODO.txt.